### PR TITLE
refactor: externalizar credenciales de BD mediante variables de entorno

### DIFF
--- a/Online-Food-Ordering-Backend/src/main/resources/application.properties
+++ b/Online-Food-Ordering-Backend/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 spring.application.name=Online Food Ordering;
 server.port=5454
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url=jdbc:mysql://localhost:3306/OnlineFoodOrdering
-spring.datasource.username=root
-spring.datasource.password=1234567Cc.
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USER_NAME}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql: true


### PR DESCRIPTION

Se externalizan las credenciales de la base de datos mediante variables de entorno, eliminando los datos sensibles del archivo de configuración.
Esto mejora la seguridad del proyecto y facilita la gestión de configuraciones en distintos entornos.

**Beneficios**
- Evita exponer información sensible en el repositorio.
- Permite modificar configuraciones sin alterar el código fuente.
- Facilita el despliegue en entornos como desarrollo, pruebas o producción.

**Recomendación**
Para ejecutar el proyecto localmente, asegúrate de definir las variables de entorno en tu editor o terminal antes de iniciar la aplicación.
El sistema funcionará correctamente siempre que las variables estén disponibles.